### PR TITLE
Revert "docs(readme): add plugin override directions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ By default this package will enable @iopipe/trace and @iopipe/event-info plugins
 - [IOpipe Documentation](https://github.com/iopipe/iopipe-js-core#readme)
 - [IOpipe Tracing Plugin Documentation](https://github.com/iopipe/iopipe-plugin-trace#readme)
 
-If you would like to override a plugin for a purpose such as testing out a beta release, you can install the plugin directly and it will be picked up automatically, like:
-`npm install @iopipe/trace@TAG`
-
 Example With Tracing, Custom Metrics, and Labels (ES6 Module Format):
 
 ```js


### PR DESCRIPTION
Reverts iopipe/iopipe-js#16

After a full end-to-end test of this, the instructions for using a beta release are not quite this simple.